### PR TITLE
fix: make defaultComparator provide a strict partial order

### DIFF
--- a/b+tree.d.ts
+++ b/b+tree.d.ts
@@ -6,7 +6,7 @@ export declare type EditRangeResult<V, R = number> = {
     delete?: boolean;
 };
 /**
- * numbers, strings and arrays thereof, and objects that have a valueOf() method returning a number or string like Dates.
+ * Types that BTree supports by default
  */
 export declare type DefaultComparable = number | string | (number | string)[] | {
     valueOf: () => number | string | (number | string)[];

--- a/b+tree.d.ts
+++ b/b+tree.d.ts
@@ -29,6 +29,8 @@ export declare function defaultComparator(a: DefaultComparable, b: DefaultCompar
  * Unlike defaultComparator, this comparator doesn't support mixed types correctly,
  * i.e. use it with `BTree<string>` or `BTree<number>` but not `BTree<string|number>`.
  *
+ * NaN is not supported.
+ *
  * Note: null is treated like 0 when compared with numbers or Date, but in general
  *   null is not ordered with respect to strings (neither greater nor less), and
  *   undefined is not ordered with other types.

--- a/b+tree.d.ts
+++ b/b+tree.d.ts
@@ -32,10 +32,6 @@ export declare function compareFiniteNumbers(a: number, b: number): number;
  */
 export declare function compareStrings(a: string, b: string): number;
 /**
- * If a and b are arrays, they are compared using '<' and '>', which may cause unexpected equality, for example [1] will be considered equal to ['1'].
- */
-export declare function compareFiniteNumbersOrStringOrArray(a: number | string | (number | string)[], b: number | string | (number | string)[]): number;
-/**
  * A reasonably fast collection of key-value pairs with a powerful API.
  * Largely compatible with the standard Map. BTree is a B+ tree data structure,
  * so the collection is sorted by key.

--- a/b+tree.d.ts
+++ b/b+tree.d.ts
@@ -8,8 +8,8 @@ export declare type EditRangeResult<V, R = number> = {
 /**
  * Types that BTree supports by default
  */
-export declare type DefaultComparable = number | string | (number | string)[] | {
-    valueOf: () => number | string | (number | string)[];
+export declare type DefaultComparable = number | string | Date | boolean | null | undefined | (number | string)[] | {
+    valueOf: () => number | string | Date | boolean | null | undefined | (number | string)[];
 };
 /**
  * Compares DefaultComparables to form a strict partial ordering.
@@ -22,15 +22,18 @@ export declare type DefaultComparable = number | string | (number | string)[] | 
  */
 export declare function defaultComparator(a: DefaultComparable, b: DefaultComparable): number;
 /**
- * Compares finite numbers to form a strict partial ordering.
+ * Compares items using the < and > operators. This function is probably slightly
+ * faster than the defaultComparator for Dates and strings, but has not been benchmarked.
+ * Unlike defaultComparator, this comparator doesn't support mixed types correctly,
+ * i.e. use it with `BTree<string>` or `BTree<Date>` but not `BTree<string|Date>`.
  *
- * Handles +/-0 like Map: -0 is equal to +0.
+ * Note: null compares as less than any number or Date, but in general null is
+ *   incomparable with strings, and undefined is not comparable with other types
+ *   using the > and < operators
  */
-export declare function compareFiniteNumbers(a: number, b: number): number;
-/**
- * Compares strings lexically to form a strict partial ordering.
- */
-export declare function compareStrings(a: string, b: string): number;
+export declare function simpleComparator(a: string, b: string): number;
+export declare function simpleComparator(a: number | null, b: number | null): number;
+export declare function simpleComparator(a: Date | null, b: Date | null): number;
 /**
  * A reasonably fast collection of key-value pairs with a powerful API.
  * Largely compatible with the standard Map. BTree is a B+ tree data structure,

--- a/b+tree.d.ts
+++ b/b+tree.d.ts
@@ -16,24 +16,27 @@ export declare type DefaultComparable = number | string | Date | boolean | null 
  *
  * Handles +/-0 and NaN like Map: NaN is equal to NaN, and -0 is equal to +0.
  *
- * Arrays are compared using '<' and '>', which may cause unexpected equality: for example [1] will be considered equal to ['1'].
+ * Arrays are compared using '<' and '>', which may cause unexpected equality:
+ * for example [1] will be considered equal to ['1'].
  *
- * Two objects with equal valueOf compare the same, but compare unequal to primitives that have the same value.
+ * Two objects with equal valueOf compare the same, but compare unequal to
+ * primitives that have the same value.
  */
 export declare function defaultComparator(a: DefaultComparable, b: DefaultComparable): number;
 /**
  * Compares items using the < and > operators. This function is probably slightly
  * faster than the defaultComparator for Dates and strings, but has not been benchmarked.
  * Unlike defaultComparator, this comparator doesn't support mixed types correctly,
- * i.e. use it with `BTree<string>` or `BTree<Date>` but not `BTree<string|Date>`.
+ * i.e. use it with `BTree<string>` or `BTree<number>` but not `BTree<string|number>`.
  *
- * Note: null compares as less than any number or Date, but in general null is
- *   incomparable with strings, and undefined is not comparable with other types
- *   using the > and < operators
+ * Note: null is treated like 0 when compared with numbers or Date, but in general
+ *   null is not ordered with respect to strings (neither greater nor less), and
+ *   undefined is not ordered with other types.
  */
 export declare function simpleComparator(a: string, b: string): number;
 export declare function simpleComparator(a: number | null, b: number | null): number;
 export declare function simpleComparator(a: Date | null, b: Date | null): number;
+export declare function simpleComparator(a: (number | string)[], b: (number | string)[]): number;
 /**
  * A reasonably fast collection of key-value pairs with a powerful API.
  * Largely compatible with the standard Map. BTree is a B+ tree data structure,

--- a/b+tree.js
+++ b/b+tree.js
@@ -13,7 +13,7 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.EmptyBTree = exports.compareFiniteNumbersOrStringOrArray = exports.compareStrings = exports.compareFiniteNumbers = exports.defaultComparator = void 0;
+exports.EmptyBTree = exports.compareStrings = exports.compareFiniteNumbers = exports.defaultComparator = void 0;
 /**
  * Compares DefaultComparables to form a strict partial ordering.
  *
@@ -24,9 +24,17 @@ exports.EmptyBTree = exports.compareFiniteNumbersOrStringOrArray = exports.compa
  * Two objects with equal valueOf compare the same, but compare unequal to primitives that have the same value.
  */
 function defaultComparator(a, b) {
-    // Compare types first.
+    // Special case finite numbers first for performance.
     // Note that the trick of using 'a - b' the checking for NaN to detect non numbers values does not work if the strings are numeric (ex: "5"),
     // leading most comparison functions using that approach to fail to have transitivity.
+    if (Number.isFinite(a) && Number.isFinite(b)) {
+        // Does not partially order NaNs or infinite values, but thats fine since they can't reach here.
+        // This will handle -0 and 0 as equal.
+        return a - b;
+    }
+    // Compare types and order values of different types by type.
+    // This prevents implicit conversion of strings to numbers from causing invaliding ordering,
+    // and generally simplifies which cases need to be considered below.
     var ta = typeof a;
     var tb = typeof b;
     if (ta !== tb) {
@@ -81,21 +89,6 @@ function compareStrings(a, b) {
     return a > b ? 1 : a === b ? 0 : -1;
 }
 exports.compareStrings = compareStrings;
-;
-/**
- * If a and b are arrays, they are compared using '<' and '>', which may cause unexpected equality, for example [1] will be considered equal to ['1'].
- */
-function compareFiniteNumbersOrStringOrArray(a, b) {
-    // Strings can not be ordered relative to numbers using '<' and '>' since no matter the order, the comparison will return false.
-    var ta = typeof a;
-    var tb = typeof b;
-    if (ta !== tb) {
-        return ta < tb ? -1 : 1;
-    }
-    // Use < and > instead of < and === so arrays work correctly.
-    return a > b ? 1 : a < b ? -1 : 0;
-}
-exports.compareFiniteNumbersOrStringOrArray = compareFiniteNumbersOrStringOrArray;
 ;
 /**
  * A reasonably fast collection of key-value pairs with a powerful API.

--- a/b+tree.js
+++ b/b+tree.js
@@ -68,7 +68,7 @@ function defaultComparator(a, b) {
         return Number.isNaN(b) ? 0 : -1;
     else if (Number.isNaN(b))
         return 1;
-    // This could be two objects (e.g. [7] and ['7']), that aren't greater or less
+    // This could be two objects (e.g. [7] and ['7']) that aren't ordered
     return Array.isArray(a) ? 0 : Number.NaN;
 }
 exports.defaultComparator = defaultComparator;

--- a/b+tree.test.ts
+++ b/b+tree.test.ts
@@ -1,4 +1,4 @@
-import BTree, {IMap, EmptyBTree, defaultComparator, compareFiniteNumbers, compareStrings} from './b+tree';
+import BTree, {IMap, EmptyBTree, defaultComparator, simpleComparator} from './b+tree';
 import SortedArray from './sorted-array';
 import MersenneTwister from 'mersenne-twister';
 
@@ -50,8 +50,8 @@ describe('defaultComparator', () =>
 
 describe('compareFiniteNumbers', () =>
 {
-  const sorted = [-10, -1, -0, 0, 1, 2, 10];
-  testComparison(compareFiniteNumbers, sorted, sorted, [[-0, 0]]);
+  const sorted = [-Infinity, -10, -1, -0, 0, 1, 2, 10, Infinity];
+  testComparison(simpleComparator, sorted, sorted, [[-0, 0]]);
 });
 
 describe('compareStrings', () =>
@@ -68,7 +68,7 @@ describe('compareStrings', () =>
     '10',
     "NaN",
   ];;
-  testComparison(compareStrings, [], values, []);
+  testComparison(simpleComparator, [], values, []);
 });
 
 /**
@@ -76,7 +76,7 @@ describe('compareStrings', () =>
  * Additionally confirms that the comparison function has the correct definition of equality via expectedDuplicates.
  */
 function testComparison(comparison: (a: any, b: any) => number, inOrder: any[], values: any[], expectedDuplicates: [any, any][] = []) {
-  function check(a: any, b: any): number {
+  function compare(a: any, b: any): number {
     const v = comparison(a, b);
     expect(typeof v).toEqual('number');
     expect(v === v).toEqual(true); // Not NaN
@@ -91,7 +91,7 @@ function testComparison(comparison: (a: any, b: any) => number, inOrder: any[], 
     let duplicates = [];
     for (let i = 0; i < values.length; i++) {
       for (let j = i + 1; j < values.length; j++) {
-        if (check(values[i], values[j]) === 0) {
+        if (compare(values[i], values[j]) === 0) {
           duplicates.push([values[i], values[j]]);
         }
       }
@@ -117,16 +117,16 @@ function testComparison(comparison: (a: any, b: any) => number, inOrder: any[], 
     const asymmetric = []
     for (const a of values) {
       // irreflexive: compare(a, a) === 0
-      if(check(a, a) !== 0) irreflexive.push(a);
+      if(compare(a, a) !== 0) irreflexive.push(a);
       for (const b of values) {
         for (const c of values) {
           // transitive: if compare(a, b) < 0 and compare(b, c) < 0 then compare(a, c) < 0
-          if (check(a, b) < 0 && check(b, c) < 0) {
-            if(check(a, c) !== -1) transitive.push([a, b, c]);
+          if (compare(a, b) < 0 && compare(b, c) < 0) {
+            if(compare(a, c) !== -1) transitive.push([a, b, c]);
           }
         }
         // sign(compare(a, b)) === -sign(compare(b, a))
-        if(check(a, b) !== -check(b, a)) asymmetric.push([a, b]);
+        if(compare(a, b) !== -compare(b, a)) asymmetric.push([a, b]);
       }
     }
     expect(irreflexive).toEqual([]);

--- a/b+tree.test.ts
+++ b/b+tree.test.ts
@@ -1,4 +1,4 @@
-import BTree, {IMap, EmptyBTree, defaultComparator, compareFiniteNumbers, compareFiniteNumbersOrStringOrArray, compareStrings} from './b+tree';
+import BTree, {IMap, EmptyBTree, defaultComparator, compareFiniteNumbers, compareStrings} from './b+tree';
 import SortedArray from './sorted-array';
 import MersenneTwister from 'mersenne-twister';
 
@@ -70,31 +70,6 @@ describe('compareStrings', () =>
   ];;
   testComparison(compareStrings, [], values, []);
 });
-
-describe('compareFiniteNumbersOrStringOrArray', () =>
-{
-  const values = [
-    '24x',
-    '0',
-    '1',
-    '3',
-    'String',
-    '10',
-    0,
-    "NaN",
-    -0,
-    1,
-    10,
-    2,
-    [],
-    '[]',
-    [1],
-    ['1']
-  ];
-  const sorted = [-10, -1, -0, 0, 1, 2, 10];
-  testComparison(compareFiniteNumbersOrStringOrArray, sorted, values, [[0, -0], [[1], ['1']]]);
-});
-
 
 /**
  * Tests a comparison function, ensuring it produces a strict partial order over the provided values.

--- a/b+tree.test.ts
+++ b/b+tree.test.ts
@@ -48,13 +48,13 @@ describe('defaultComparator', () =>
   testComparison(defaultComparator, sorted, values, [[dateA, dateA2], [0, -0], [[1], ['1']]]);
 });
 
-describe('compareFiniteNumbers', () =>
+describe('simpleComparator with non-NaN numbers and null', () =>
 {
-  const sorted = [-Infinity, -10, -1, -0, 0, 1, 2, 10, Infinity];
-  testComparison(simpleComparator, sorted, sorted, [[-0, 0]]);
+  const sorted = [-Infinity, -10, -1, -0, 0, null, 1, 2, 10, Infinity];
+  testComparison<number | null>(simpleComparator, sorted, sorted, [[-0, 0], [-0, null], [0, null]]);
 });
 
-describe('compareStrings', () =>
+describe('simpleComparator with strings', () =>
 {
   const values = [
     '24x',
@@ -68,15 +68,40 @@ describe('compareStrings', () =>
     '10',
     "NaN",
   ];;
-  testComparison(simpleComparator, [], values, []);
+  testComparison<string>(simpleComparator, [], values, []);
+});
+
+describe('simpleComparator with Date', () =>
+{
+  const dateA = new Date(Date.UTC(96, 1, 2, 3, 4, 5));
+  const dateA2 = new Date(Date.UTC(96, 1, 2, 3, 4, 5));
+  const dateB = new Date(Date.UTC(96, 1, 2, 3, 4, 6));
+  const values = [
+    dateA,
+    dateA2,
+    dateB,
+    null,
+  ];
+  testComparison<Date>(simpleComparator, [], values, [[dateA, dateA2]]);
+});
+
+describe('simpleComparator arrays', () =>
+{
+  const values = [
+    [],
+    [1],
+    ['1'],
+    [2],
+  ];
+  testComparison<(number|string)[] >(simpleComparator, [], values, [[[1], ['1']]]);
 });
 
 /**
  * Tests a comparison function, ensuring it produces a strict partial order over the provided values.
  * Additionally confirms that the comparison function has the correct definition of equality via expectedDuplicates.
  */
-function testComparison(comparison: (a: any, b: any) => number, inOrder: any[], values: any[], expectedDuplicates: [any, any][] = []) {
-  function compare(a: any, b: any): number {
+function testComparison<T>(comparison: (a: T, b: T) => number, inOrder: T[], values: T[], expectedDuplicates: [T, T][] = []) {
+  function compare(a: T, b: T): number {
     const v = comparison(a, b);
     expect(typeof v).toEqual('number');
     if (v !== v)

--- a/b+tree.test.ts
+++ b/b+tree.test.ts
@@ -79,6 +79,8 @@ function testComparison(comparison: (a: any, b: any) => number, inOrder: any[], 
   function compare(a: any, b: any): number {
     const v = comparison(a, b);
     expect(typeof v).toEqual('number');
+    if (v !== v)
+      console.log('!!!', a, b);
     expect(v === v).toEqual(true); // Not NaN
     return Math.sign(v);
   }

--- a/b+tree.ts
+++ b/b+tree.ts
@@ -31,7 +31,7 @@ type index = number;
 //   - V8 source (NewElementsCapacity in src/objects.h): arrays grow by 50% + 16 elements
 
 /**
- * numbers, strings and arrays thereof, and objects that have a valueOf() method returning a number or string like Dates.
+ * Types that BTree supports by default
  */
 export type DefaultComparable = number | string | (number | string)[] | { valueOf: ()=> number | string | (number | string)[] };
 

--- a/b+tree.ts
+++ b/b+tree.ts
@@ -102,6 +102,8 @@ export function defaultComparator(a: DefaultComparable, b: DefaultComparable): n
  * Unlike defaultComparator, this comparator doesn't support mixed types correctly, 
  * i.e. use it with `BTree<string>` or `BTree<number>` but not `BTree<string|number>`.
  * 
+ * NaN is not supported.
+ * 
  * Note: null is treated like 0 when compared with numbers or Date, but in general 
  *   null is not ordered with respect to strings (neither greater nor less), and 
  *   undefined is not ordered with other types.


### PR DESCRIPTION
We found a couple of bugs in defaultComparator, which can cause the tree to not perform as expected.
Specifically:

1. defaultComparator returns NaN comparing dates to strings, or numbers to non-numeric strings.
2. defaultComparator violates transitivity for strings due to numeric string subtraction (ex: "24x" < "3" <"10" but not "24x" < "10")

It turns our use-cases shouldn't be impacted by these issues (they don't mix types or numeric and non-numeric strings), but they showed in one of our prototypes, so I figured I'd send in a fix. Then I discovered that comparing things in javascript is crazy and to sort it out I had to make a proper test suite, and supporting all the cases the code looked like it should support was quite complex.
Thus I have also included a few lighter weight comparison functions for the common cases, and a robust test suite.

I'm not convinced my new defaultComparator is a good idea: perhaps something simpler would be better (ex: not handling NaN, or infinity would simplify it a bit), but I figured I'd go full in on correctness. I do consider the array handling kinda wrong still though, but its the same behavior it had before my change, but with documentation and tests.

Anyway, let me know if you want my extra comparison functions removed, or if you want adjustments to defaultComparator. I didn't do any benchmarking: I'm particularly interested if you have any opinions based on benchmark results.