### PR TITLE
Fix IsShared bug when editRange removes multiple layers

### DIFF
--- a/b+tree.js
+++ b/b+tree.js
@@ -3,10 +3,12 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
@@ -979,9 +981,16 @@ var BTree = /** @class */ (function () {
             return typeof r === "number" ? r : r.break;
         }
         finally {
-            while (root.keys.length <= 1 && !root.isLeaf)
+            var isShared = undefined;
+            while (root.keys.length <= 1 && !root.isLeaf) {
+                isShared || (isShared = root.isShared);
                 this._root = root = root.keys.length === 0 ? EmptyLeaf :
                     root.children[0];
+            }
+            // If any ancestor of the new root was shared, the new root must also be shared
+            if (isShared) {
+                root.isShared = true;
+            }
         }
     };
     /** Same as `editRange` except that the callback is called for all pairs. */

--- a/b+tree.ts
+++ b/b+tree.ts
@@ -1094,9 +1094,16 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
       var r = root.forRange(low, high, includeHigh, true, this, initialCounter || 0, onFound);
       return typeof r === "number" ? r : r.break!;
     } finally {
-      while (root.keys.length <= 1 && !root.isLeaf)
+      let isShared: undefined | true = undefined;
+      while (root.keys.length <= 1 && !root.isLeaf) {
+        isShared ||= root.isShared;
         this._root = root = root.keys.length === 0 ? EmptyLeaf :
                     (root as any as BNodeInternal<K,V>).children[0];
+      }
+      // If any ancestor of the new root was shared, the new root must also be shared
+      if (isShared) {
+        root.isShared = true;
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5944,9 +5944,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "testpack-cli": "^1.1.4",
     "ts-jest": "^26.4.3",
     "ts-node": "^7.0.1",
-    "typescript": "^3.8.3",
+    "typescript": "^4.0.8",
     "uglify-js": "^3.11.4"
   },
   "dependencies": {},


### PR DESCRIPTION
When editRange deletes enough values that it removes two layers of the tree, isShared can be set incorrectly on the new root, resulting in clones being modified when copy on write should have occurred instead.

This issue only matters when the new root is not already marked isShared, which can only occur if it's parent was not already cloned, and thus the bug can only occur when two levels of the tree are removed (because editRange always clones a shared root) AND a child of the root, which has exactly one child of its own, is the only remaining child after editRange completes. This is a pretty rare edge case, but we managed to hit it.

This PR includes a regression test as well as a fix for this case.

Also included is a version bump of typescript to include the `||=` operator used in the fix. In the current configuration typescript complied this to a backwards compatible form in javascript, so no changes to the requires ECMA script version should be involved.