### PR TITLE
fix mergeSibling not setting isShared and greedyClone(true) not deeply copying

### DIFF
--- a/b+tree.js
+++ b/b+tree.js
@@ -1530,15 +1530,14 @@ var BNodeInternal = /** @class */ (function (_super) {
         this.children.splice(i, 0, child);
         this.keys.splice(i, 0, child.maxKey());
     };
+    /**
+     * Split this node.
+     * Modifies this to remove the second half of the items, returning a separate node containing them.
+     */
     BNodeInternal.prototype.splitOffRightSide = function () {
+        // assert !this.isShared;
         var half = this.children.length >> 1;
-        var halfChildren = this.children.splice(half);
-        // These children are already have a parent (`this`),
-        // and we are creating a new parent (the returned node),
-        // so mark them as shared.
-        for (var i = 0; i < halfChildren.length; i++)
-            halfChildren[i].isShared = true;
-        return new BNodeInternal(halfChildren, this.keys.splice(half));
+        return new BNodeInternal(this.children.splice(half), this.keys.splice(half));
     };
     BNodeInternal.prototype.takeFromRight = function (rhs) {
         // Reminder: parent node must update its copy of key for this node

--- a/b+tree.test.ts
+++ b/b+tree.test.ts
@@ -468,6 +468,62 @@ describe("cloning and sharing tests", () => {
     // do some private field access and any casts to make it work.
     expect((clone['_root'] as any).children[0].children[0]).not.toBe((tree['_root'] as any).children[0].children[0]);
   });
+
+  test("Regression test for mergeSibling setting isShared", () => {
+    // This tests make a 3 layer tree (height = 2), so use a small branching factor.
+    const maxNodeSize = 4;
+    const tree = new BTree<number, number>(
+      undefined,
+      simpleComparator,
+      maxNodeSize
+    );
+    // Build a 3 layer tree
+    const count =maxNodeSize * maxNodeSize * maxNodeSize;
+    for (
+      let index = 0;
+      index < count;
+      index++
+    ) {
+      tree.set(index, 0);
+    }
+    // Leaf nodes don't count, so this is depth 2
+    expect(tree.height).toBe(2);
+
+    // Delete most of the keys so merging interior nodes is possible, marking all nodes as shared.
+    for (
+      let index = 0;
+      index < maxNodeSize * maxNodeSize * maxNodeSize;
+      index++
+    ) {
+      if (index % 4 !== 0) {
+        tree.delete(index);
+      }
+    }
+
+    const deepClone = tree.greedyClone(true);
+    const cheapClone = tree.clone();
+
+    // These two clones should remain unchanged forever.
+    // The bug this is testing for resulted in the cheap clone getting modified:
+    // we will compare it against the deep clone to confirm it does not.
+
+
+    // Delete a bunch more nodes, causing merging.
+    for (
+      let index = 0;
+      index < maxNodeSize * maxNodeSize * maxNodeSize;
+      index++
+    ) {
+      if (index % 16 !== 0) {
+        tree.delete(index);
+      }
+    }
+
+    const different: number[] = [];
+    const onDiff = (k) => { different.push(k); }
+    deepClone.diffAgainst(cheapClone, onDiff, onDiff, onDiff);
+    expect(different).toEqual([]);
+  });
 });
 
 describe('B+ tree with fanout 32', testBTree.bind(null, 32));

--- a/b+tree.test.ts
+++ b/b+tree.test.ts
@@ -440,35 +440,6 @@ describe("cloning and sharing tests", () => {
     expect((clone['_root'] as any).children[0].children[0]).not.toBe((tree['_root'] as any).children[0].children[0]);
   });
 
-  test("Regression test for greedyClone(true) not copying all nodes", () => {
-    // This tests make a 3 layer tree (height = 2), so use a small branching factor.
-    const maxNodeSize = 4;
-    const tree = new BTree<number, number>(
-      undefined,
-      simpleComparator,
-      maxNodeSize
-    );
-    // Build a 3 layer tree.
-    for (
-      let index = 0;
-      index < maxNodeSize * maxNodeSize + 1;
-      index++
-    ) {
-      tree.set(index, 0);
-    }
-    // Leaf nodes don't count, so this is depth 2
-    expect(tree.height).toBe(2);
-
-    const clone = tree.greedyClone(true);
-
-    // The bug was that `force` was not passed down. This meant that non-shared nodes below the second layer would not be cloned.
-    // Thus we check that the third layer of this tree did get cloned.
-    // Since this depends on private APIs and types,
-    // and this package currently has no way to expose them to tests without exporting them from the package,
-    // do some private field access and any casts to make it work.
-    expect((clone['_root'] as any).children[0].children[0]).not.toBe((tree['_root'] as any).children[0].children[0]);
-  });
-
   test("Regression test for mergeSibling setting isShared", () => {
     // This tests make a 3 layer tree (height = 2), so use a small branching factor.
     const maxNodeSize = 4;

--- a/b+tree.test.ts
+++ b/b+tree.test.ts
@@ -478,7 +478,7 @@ describe("cloning and sharing tests", () => {
       maxNodeSize
     );
     // Build a 3 layer tree
-    const count =maxNodeSize * maxNodeSize * maxNodeSize;
+    const count = maxNodeSize * maxNodeSize * maxNodeSize;
     for (
       let index = 0;
       index < count;
@@ -492,7 +492,7 @@ describe("cloning and sharing tests", () => {
     // Delete most of the keys so merging interior nodes is possible, marking all nodes as shared.
     for (
       let index = 0;
-      index < maxNodeSize * maxNodeSize * maxNodeSize;
+      index < count;
       index++
     ) {
       if (index % 4 !== 0) {
@@ -507,11 +507,10 @@ describe("cloning and sharing tests", () => {
     // The bug this is testing for resulted in the cheap clone getting modified:
     // we will compare it against the deep clone to confirm it does not.
 
-
     // Delete a bunch more nodes, causing merging.
     for (
       let index = 0;
-      index < maxNodeSize * maxNodeSize * maxNodeSize;
+      index < count;
       index++
     ) {
       if (index % 16 !== 0) {
@@ -520,7 +519,7 @@ describe("cloning and sharing tests", () => {
     }
 
     const different: number[] = [];
-    const onDiff = (k) => { different.push(k); }
+    const onDiff = (k: number) => { different.push(k); }
     deepClone.diffAgainst(cheapClone, onDiff, onDiff, onDiff);
     expect(different).toEqual([]);
   });

--- a/b+tree.ts
+++ b/b+tree.ts
@@ -1682,15 +1682,14 @@ class BNodeInternal<K,V> extends BNode<K,V> {
     this.keys.splice(i, 0, child.maxKey());
   }
 
+  /**
+   * Split this node.
+   * Modifies this to remove the second half of the items, returning a separate node containing them.
+   */
   splitOffRightSide() {
-    const half = this.children.length >> 1;
-    const halfChildren = this.children.splice(half);
-    // These children are already have a parent (`this`),
-    // and we are creating a new parent (the returned node),
-    // so mark them as shared.
-    for (var i = 0; i < halfChildren.length; i++)
-      halfChildren[i].isShared = true;
-    return new BNodeInternal<K,V>(halfChildren, this.keys.splice(half));
+    // assert !this.isShared;
+    var half = this.children.length >> 1;
+    return new BNodeInternal<K,V>(this.children.splice(half), this.keys.splice(half));
   }
 
   takeFromRight(rhs: BNode<K,V>) {


### PR DESCRIPTION
This fixes 2 separate bugs:

1. greedyClone(true) did not copy all nodes, since the force parameter was not passed when recursing.
2. mergeSibling could result in two references to the same nodes without marking them as shared.

Additionally some more documentation has been added about what code is responsible for setting isShared so it's easier to tell if a given function is correct, and if a caller to it is correct.

Our usage exposed the bug in mergeSibling (trees were becoming corrupted when their clones were edited), and I found the issue with greedyClone while investigating it.

Regression tests for both issues are included.