### PR TITLE
fix: Fix an edge case in extended algorithms

### DIFF
--- a/extended/decompose.js
+++ b/extended/decompose.js
@@ -315,6 +315,8 @@ function buildFromDecomposition(constructor, branchingFactor, decomposed, cmp, m
     var heights = decomposed.heights, nodes = decomposed.nodes, tallestIndex = decomposed.tallestIndex;
     (0, b_tree_1.check)(heights.length === nodes.length, "Decompose result has mismatched heights and nodes.");
     var disjointEntryCount = heights.length;
+    if (disjointEntryCount === 0)
+        return new constructor(undefined, cmp, maxNodeSize);
     // Now we have a set of disjoint subtrees and we need to merge them into a single tree.
     // To do this, we start with the tallest subtree from the disjoint set and, for all subtrees
     // to the "right" and "left" of it in sorted order, we append them onto the appropriate side

--- a/extended/decompose.ts
+++ b/extended/decompose.ts
@@ -404,6 +404,8 @@ export function buildFromDecomposition<TBTree extends BTree<K, V>, K, V>(
   const { heights, nodes, tallestIndex } = decomposed;
   check(heights.length === nodes.length, "Decompose result has mismatched heights and nodes.");
   const disjointEntryCount = heights.length;
+  if (disjointEntryCount === 0)
+    return new constructor(undefined, cmp, maxNodeSize) as unknown as TBTree;
 
   // Now we have a set of disjoint subtrees and we need to merge them into a single tree.
   // To do this, we start with the tallest subtree from the disjoint set and, for all subtrees

--- a/extended/diffAgainst.d.ts
+++ b/extended/diffAgainst.d.ts
@@ -6,6 +6,8 @@ import BTree from '../b+tree';
  * (obtained by calling the `clone` or `with` APIs) and will avoid any iteration of shared state.
  * The handlers can cause computation to early exit by returning `{ break: R }`.
  * Neither collection should be mutated during the comparison (inside your callbacks), as this method assumes they remain stable.
+ * Time complexity is O(N + M) in the worst case, but is linear in the number of nodes and entries visited after
+ * shared subtrees have been skipped.
  * @param treeA The tree whose differences will be reported via the callbacks.
  * @param treeB The tree to compute a diff against.
  * @param onlyA Callback invoked for all keys only present in `treeA`.

--- a/extended/diffAgainst.js
+++ b/extended/diffAgainst.js
@@ -8,6 +8,8 @@ var b_tree_1 = require("../b+tree");
  * (obtained by calling the `clone` or `with` APIs) and will avoid any iteration of shared state.
  * The handlers can cause computation to early exit by returning `{ break: R }`.
  * Neither collection should be mutated during the comparison (inside your callbacks), as this method assumes they remain stable.
+ * Time complexity is O(N + M) in the worst case, but is linear in the number of nodes and entries visited after
+ * shared subtrees have been skipped.
  * @param treeA The tree whose differences will be reported via the callbacks.
  * @param treeB The tree to compute a diff against.
  * @param onlyA Callback invoked for all keys only present in `treeA`.

--- a/extended/diffAgainst.ts
+++ b/extended/diffAgainst.ts
@@ -9,6 +9,8 @@ import { type BTreeWithInternals } from './shared';
  * (obtained by calling the `clone` or `with` APIs) and will avoid any iteration of shared state.
  * The handlers can cause computation to early exit by returning `{ break: R }`.
  * Neither collection should be mutated during the comparison (inside your callbacks), as this method assumes they remain stable.
+ * Time complexity is O(N + M) in the worst case, but is linear in the number of nodes and entries visited after
+ * shared subtrees have been skipped.
  * @param treeA The tree whose differences will be reported via the callbacks.
  * @param treeB The tree to compute a diff against.
  * @param onlyA Callback invoked for all keys only present in `treeA`.

--- a/extended/forEachKeyInBoth.d.ts
+++ b/extended/forEachKeyInBoth.d.ts
@@ -3,11 +3,10 @@ import BTree from '../b+tree';
  * Calls the supplied `callback` for each key/value pair shared by both trees, in sorted key order.
  * Neither tree is modified.
  *
- * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint key ranges between the trees, because whole non-intersecting subtrees
- * are skipped.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
  * @param treeA First tree to compare.
  * @param treeB Second tree to compare.
  * @param callback Invoked for keys that appear in both trees. It can cause iteration to early exit by returning `{ break: R }`.

--- a/extended/forEachKeyInBoth.js
+++ b/extended/forEachKeyInBoth.js
@@ -6,11 +6,10 @@ var parallelWalk_1 = require("./parallelWalk");
  * Calls the supplied `callback` for each key/value pair shared by both trees, in sorted key order.
  * Neither tree is modified.
  *
- * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint key ranges between the trees, because whole non-intersecting subtrees
- * are skipped.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
  * @param treeA First tree to compare.
  * @param treeB Second tree to compare.
  * @param callback Invoked for keys that appear in both trees. It can cause iteration to early exit by returning `{ break: R }`.

--- a/extended/forEachKeyInBoth.ts
+++ b/extended/forEachKeyInBoth.ts
@@ -6,11 +6,10 @@ import { createCursor, moveForwardOne, moveTo, getKey, noop } from "./parallelWa
  * Calls the supplied `callback` for each key/value pair shared by both trees, in sorted key order.
  * Neither tree is modified.
  *
- * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint key ranges between the trees, because whole non-intersecting subtrees
- * are skipped.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
  * @param treeA First tree to compare.
  * @param treeB Second tree to compare.
  * @param callback Invoked for keys that appear in both trees. It can cause iteration to early exit by returning `{ break: R }`.

--- a/extended/forEachKeyNotIn.d.ts
+++ b/extended/forEachKeyNotIn.d.ts
@@ -3,10 +3,11 @@ import BTree from '../b+tree';
  * Calls the supplied `callback` for each key/value pair that is in `includeTree` but not in `excludeTree`
  * (set subtraction). The callback runs in sorted key order and neither tree is modified.
  *
- * Complexity is O(N + M) when the key ranges overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint ranges between the trees, because non-overlapping subtrees are skipped.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the sizes of `includeTree` and `excludeTree`, respectively, `I` the number of keys present
+ * in both trees, `U = N + M - 2I` the number of keys present in exactly one tree, `H` the larger tree height,
+ * and `G` the number of maximal runs of keys belonging exclusively to one particular tree in merged key order.
+ * With a fixed max node size and normally occupied nodes, the complexity is
+ * `O(min(I + U, N + G * H))`.
  * @param includeTree The tree to iterate keys from.
  * @param excludeTree Keys present in this tree are omitted from the callback.
  * @param callback Invoked for keys that are in `includeTree` but not `excludeTree`. It can cause iteration to early exit by returning `{ break: R }`.

--- a/extended/forEachKeyNotIn.js
+++ b/extended/forEachKeyNotIn.js
@@ -6,10 +6,11 @@ var parallelWalk_1 = require("./parallelWalk");
  * Calls the supplied `callback` for each key/value pair that is in `includeTree` but not in `excludeTree`
  * (set subtraction). The callback runs in sorted key order and neither tree is modified.
  *
- * Complexity is O(N + M) when the key ranges overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint ranges between the trees, because non-overlapping subtrees are skipped.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the sizes of `includeTree` and `excludeTree`, respectively, `I` the number of keys present
+ * in both trees, `U = N + M - 2I` the number of keys present in exactly one tree, `H` the larger tree height,
+ * and `G` the number of maximal runs of keys belonging exclusively to one particular tree in merged key order.
+ * With a fixed max node size and normally occupied nodes, the complexity is
+ * `O(min(I + U, N + G * H))`.
  * @param includeTree The tree to iterate keys from.
  * @param excludeTree Keys present in this tree are omitted from the callback.
  * @param callback Invoked for keys that are in `includeTree` but not `excludeTree`. It can cause iteration to early exit by returning `{ break: R }`.

--- a/extended/forEachKeyNotIn.ts
+++ b/extended/forEachKeyNotIn.ts
@@ -6,10 +6,11 @@ import { createCursor, moveForwardOne, moveTo, getKey, noop } from "./parallelWa
  * Calls the supplied `callback` for each key/value pair that is in `includeTree` but not in `excludeTree`
  * (set subtraction). The callback runs in sorted key order and neither tree is modified.
  *
- * Complexity is O(N + M) when the key ranges overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint ranges between the trees, because non-overlapping subtrees are skipped.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the sizes of `includeTree` and `excludeTree`, respectively, `I` the number of keys present
+ * in both trees, `U = N + M - 2I` the number of keys present in exactly one tree, `H` the larger tree height,
+ * and `G` the number of maximal runs of keys belonging exclusively to one particular tree in merged key order.
+ * With a fixed max node size and normally occupied nodes, the complexity is
+ * `O(min(I + U, N + G * H))`.
  * @param includeTree The tree to iterate keys from.
  * @param excludeTree Keys present in this tree are omitted from the callback.
  * @param callback Invoked for keys that are in `includeTree` but not `excludeTree`. It can cause iteration to early exit by returning `{ break: R }`.

--- a/extended/index.d.ts
+++ b/extended/index.d.ts
@@ -30,6 +30,8 @@ export declare class BTreeEx<K = any, V = any> extends BTree<K, V> {
      * (obtained by calling the `clone` or `with` APIs) and will avoid any iteration of shared state.
      * The handlers can cause computation to early exit by returning `{ break: R }`.
      * Neither collection should be mutated during the comparison (inside your callbacks), as this method assumes they remain stable.
+     * Time complexity is O(N + M) in the worst case, but is linear in the number of nodes and entries visited after
+     * shared subtrees have been skipped.
      * @param other The tree to compute a diff against.
      * @param onlyThis Callback invoked for all keys only present in `this`.
      * @param onlyOther Callback invoked for all keys only present in `other`.
@@ -48,10 +50,10 @@ export declare class BTreeEx<K = any, V = any> extends BTree<K, V> {
      * Calls the supplied `callback` for each key/value pair shared by this tree and `other`, in sorted key order.
      * Neither tree is modified.
      *
-     * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
-     * where `D` is the number of disjoint key ranges between the trees, because disjoint subtrees are skipped.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+     * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+     * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+     * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
      * @param other The other tree to compare with this one.
      * @param callback Called for keys that appear in both trees. It can cause iteration to early exit by returning `{ break: R }`.
      * @returns The first `break` payload returned by the callback, or `undefined` if the walk finishes.
@@ -64,10 +66,11 @@ export declare class BTreeEx<K = any, V = any> extends BTree<K, V> {
      * Calls the supplied `callback` for each key/value pair that exists in this tree but not in `other`
      * (set subtraction). The callback runs in sorted key order and neither tree is modified.
      *
-     * Complexity is O(N + M) when the key ranges overlap heavily, and additionally bounded by O(log(N + M) * D)
-     * where `D` is the number of disjoint ranges between the trees, because non-overlapping subtrees are skipped.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the sizes of this tree and `other`, respectively, `I` the number of keys present in both
+     * trees, `U = N + M - 2I` the number of keys present in exactly one tree, `H` the larger tree height, and `G`
+     * the number of maximal runs of keys belonging exclusively to one particular tree in merged key order.
+     * With a fixed max node size and normally occupied nodes, the complexity is
+     * `O(min(I + U, N + G * H))`.
      * @param other Keys present in this tree will be omitted from the callback.
      * @param callback Invoked for keys unique to `this`. It can cause iteration to early exit by returning `{ break: R }`.
      * @returns The first `break` payload returned by the callback, or `undefined` if all qualifying keys are visited.
@@ -80,10 +83,10 @@ export declare class BTreeEx<K = any, V = any> extends BTree<K, V> {
      * Returns a new tree containing only keys present in both trees.
      * Neither tree is modified.
      *
-     * Complexity is O(N + M) in the fully overlapping case and additionally bounded by O(log(N + M) * D),
-     * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+     * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+     * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+     * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
      * @param other The other tree to intersect with this one.
      * @param combineFn Called for keys that appear in both trees. Return the desired value.
      * @returns A new `BTreeEx` populated with the intersection.
@@ -93,10 +96,10 @@ export declare class BTreeEx<K = any, V = any> extends BTree<K, V> {
     /**
      * Efficiently unions this tree with `other`, reusing subtrees wherever possible without modifying either input.
      *
-     * Complexity is O(N + M) in the fully overlapping case, and additionally bounded by O(log(N + M) * D)
-     * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+     * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+     * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+     * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H^2))`.
      * @param other The other tree to union with this one.
      * @param combineFn Called for keys that appear in both trees. Return the desired value, or `undefined` to omit the key.
      * @returns A new `BTreeEx` that contains the unioned key/value pairs.
@@ -107,11 +110,11 @@ export declare class BTreeEx<K = any, V = any> extends BTree<K, V> {
      * Returns a new tree containing only the keys that are present in this tree but not `other` (set subtraction).
      * Neither input tree is modified.
      *
-     * Complexity is O(N + M) for time and O(N) for allocations in the worst case. Additionally, time is bounded by
-     * O(log(N + M) * D1) and space by O(log N * D2) where `D1` is the number of disjoint key ranges between the trees
-     * and `D2` is the number of disjoint ranges inside this tree.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+     * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+     * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+     * and normally occupied nodes, the time complexity is `O(min(I + U, I + G * H^2))`.
+     * Allocations are O(N) in the worst case, but disjoint subtrees from this tree are reused.
      * @param other The tree whose keys will be removed from the result.
      * @returns A new `BTreeEx` representing `this \ other`.
      * @throws Error if the trees were created with different comparators or max node sizes.

--- a/extended/index.js
+++ b/extended/index.js
@@ -101,6 +101,8 @@ var BTreeEx = /** @class */ (function (_super) {
      * (obtained by calling the `clone` or `with` APIs) and will avoid any iteration of shared state.
      * The handlers can cause computation to early exit by returning `{ break: R }`.
      * Neither collection should be mutated during the comparison (inside your callbacks), as this method assumes they remain stable.
+     * Time complexity is O(N + M) in the worst case, but is linear in the number of nodes and entries visited after
+     * shared subtrees have been skipped.
      * @param other The tree to compute a diff against.
      * @param onlyThis Callback invoked for all keys only present in `this`.
      * @param onlyOther Callback invoked for all keys only present in `other`.
@@ -115,10 +117,10 @@ var BTreeEx = /** @class */ (function (_super) {
      * Calls the supplied `callback` for each key/value pair shared by this tree and `other`, in sorted key order.
      * Neither tree is modified.
      *
-     * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
-     * where `D` is the number of disjoint key ranges between the trees, because disjoint subtrees are skipped.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+     * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+     * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+     * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
      * @param other The other tree to compare with this one.
      * @param callback Called for keys that appear in both trees. It can cause iteration to early exit by returning `{ break: R }`.
      * @returns The first `break` payload returned by the callback, or `undefined` if the walk finishes.
@@ -131,10 +133,11 @@ var BTreeEx = /** @class */ (function (_super) {
      * Calls the supplied `callback` for each key/value pair that exists in this tree but not in `other`
      * (set subtraction). The callback runs in sorted key order and neither tree is modified.
      *
-     * Complexity is O(N + M) when the key ranges overlap heavily, and additionally bounded by O(log(N + M) * D)
-     * where `D` is the number of disjoint ranges between the trees, because non-overlapping subtrees are skipped.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the sizes of this tree and `other`, respectively, `I` the number of keys present in both
+     * trees, `U = N + M - 2I` the number of keys present in exactly one tree, `H` the larger tree height, and `G`
+     * the number of maximal runs of keys belonging exclusively to one particular tree in merged key order.
+     * With a fixed max node size and normally occupied nodes, the complexity is
+     * `O(min(I + U, N + G * H))`.
      * @param other Keys present in this tree will be omitted from the callback.
      * @param callback Invoked for keys unique to `this`. It can cause iteration to early exit by returning `{ break: R }`.
      * @returns The first `break` payload returned by the callback, or `undefined` if all qualifying keys are visited.
@@ -147,10 +150,10 @@ var BTreeEx = /** @class */ (function (_super) {
      * Returns a new tree containing only keys present in both trees.
      * Neither tree is modified.
      *
-     * Complexity is O(N + M) in the fully overlapping case and additionally bounded by O(log(N + M) * D),
-     * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+     * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+     * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+     * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
      * @param other The other tree to intersect with this one.
      * @param combineFn Called for keys that appear in both trees. Return the desired value.
      * @returns A new `BTreeEx` populated with the intersection.
@@ -162,10 +165,10 @@ var BTreeEx = /** @class */ (function (_super) {
     /**
      * Efficiently unions this tree with `other`, reusing subtrees wherever possible without modifying either input.
      *
-     * Complexity is O(N + M) in the fully overlapping case, and additionally bounded by O(log(N + M) * D)
-     * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+     * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+     * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+     * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H^2))`.
      * @param other The other tree to union with this one.
      * @param combineFn Called for keys that appear in both trees. Return the desired value, or `undefined` to omit the key.
      * @returns A new `BTreeEx` that contains the unioned key/value pairs.
@@ -178,11 +181,11 @@ var BTreeEx = /** @class */ (function (_super) {
      * Returns a new tree containing only the keys that are present in this tree but not `other` (set subtraction).
      * Neither input tree is modified.
      *
-     * Complexity is O(N + M) for time and O(N) for allocations in the worst case. Additionally, time is bounded by
-     * O(log(N + M) * D1) and space by O(log N * D2) where `D1` is the number of disjoint key ranges between the trees
-     * and `D2` is the number of disjoint ranges inside this tree.
-     * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-     * numbers of non-overlapping key ranges it is much faster.
+     * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+     * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+     * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+     * and normally occupied nodes, the time complexity is `O(min(I + U, I + G * H^2))`.
+     * Allocations are O(N) in the worst case, but disjoint subtrees from this tree are reused.
      * @param other The tree whose keys will be removed from the result.
      * @returns A new `BTreeEx` representing `this \ other`.
      * @throws Error if the trees were created with different comparators or max node sizes.

--- a/extended/index.ts
+++ b/extended/index.ts
@@ -67,6 +67,8 @@ export class BTreeEx<K = any, V = any> extends BTree<K, V> {
    * (obtained by calling the `clone` or `with` APIs) and will avoid any iteration of shared state.
    * The handlers can cause computation to early exit by returning `{ break: R }`.
    * Neither collection should be mutated during the comparison (inside your callbacks), as this method assumes they remain stable.
+   * Time complexity is O(N + M) in the worst case, but is linear in the number of nodes and entries visited after
+   * shared subtrees have been skipped.
    * @param other The tree to compute a diff against.
    * @param onlyThis Callback invoked for all keys only present in `this`.
    * @param onlyOther Callback invoked for all keys only present in `other`.
@@ -87,10 +89,10 @@ export class BTreeEx<K = any, V = any> extends BTree<K, V> {
    * Calls the supplied `callback` for each key/value pair shared by this tree and `other`, in sorted key order.
    * Neither tree is modified.
    *
-   * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
-   * where `D` is the number of disjoint key ranges between the trees, because disjoint subtrees are skipped.
-   * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-   * numbers of non-overlapping key ranges it is much faster.
+   * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+   * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+   * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+   * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
    * @param other The other tree to compare with this one.
    * @param callback Called for keys that appear in both trees. It can cause iteration to early exit by returning `{ break: R }`.
    * @returns The first `break` payload returned by the callback, or `undefined` if the walk finishes.
@@ -107,10 +109,11 @@ export class BTreeEx<K = any, V = any> extends BTree<K, V> {
    * Calls the supplied `callback` for each key/value pair that exists in this tree but not in `other`
    * (set subtraction). The callback runs in sorted key order and neither tree is modified.
    *
-   * Complexity is O(N + M) when the key ranges overlap heavily, and additionally bounded by O(log(N + M) * D)
-   * where `D` is the number of disjoint ranges between the trees, because non-overlapping subtrees are skipped.
-   * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-   * numbers of non-overlapping key ranges it is much faster.
+   * Let `N` and `M` be the sizes of this tree and `other`, respectively, `I` the number of keys present in both
+   * trees, `U = N + M - 2I` the number of keys present in exactly one tree, `H` the larger tree height, and `G`
+   * the number of maximal runs of keys belonging exclusively to one particular tree in merged key order.
+   * With a fixed max node size and normally occupied nodes, the complexity is
+   * `O(min(I + U, N + G * H))`.
    * @param other Keys present in this tree will be omitted from the callback.
    * @param callback Invoked for keys unique to `this`. It can cause iteration to early exit by returning `{ break: R }`.
    * @returns The first `break` payload returned by the callback, or `undefined` if all qualifying keys are visited.
@@ -127,10 +130,10 @@ export class BTreeEx<K = any, V = any> extends BTree<K, V> {
    * Returns a new tree containing only keys present in both trees.
    * Neither tree is modified.
    *
-   * Complexity is O(N + M) in the fully overlapping case and additionally bounded by O(log(N + M) * D),
-   * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
-   * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-   * numbers of non-overlapping key ranges it is much faster.
+   * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+   * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+   * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+   * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
    * @param other The other tree to intersect with this one.
    * @param combineFn Called for keys that appear in both trees. Return the desired value.
    * @returns A new `BTreeEx` populated with the intersection.
@@ -143,10 +146,10 @@ export class BTreeEx<K = any, V = any> extends BTree<K, V> {
   /**
    * Efficiently unions this tree with `other`, reusing subtrees wherever possible without modifying either input.
    *
-   * Complexity is O(N + M) in the fully overlapping case, and additionally bounded by O(log(N + M) * D)
-   * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
-   * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-   * numbers of non-overlapping key ranges it is much faster.
+   * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+   * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+   * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+   * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H^2))`.
    * @param other The other tree to union with this one.
    * @param combineFn Called for keys that appear in both trees. Return the desired value, or `undefined` to omit the key.
    * @returns A new `BTreeEx` that contains the unioned key/value pairs.
@@ -160,11 +163,11 @@ export class BTreeEx<K = any, V = any> extends BTree<K, V> {
    * Returns a new tree containing only the keys that are present in this tree but not `other` (set subtraction).
    * Neither input tree is modified.
    *
-   * Complexity is O(N + M) for time and O(N) for allocations in the worst case. Additionally, time is bounded by
-   * O(log(N + M) * D1) and space by O(log N * D2) where `D1` is the number of disjoint key ranges between the trees
-   * and `D2` is the number of disjoint ranges inside this tree.
-   * In practice, that means for keys of random distribution the performance is linear and for keys with significant
-   * numbers of non-overlapping key ranges it is much faster.
+   * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+   * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+   * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+   * and normally occupied nodes, the time complexity is `O(min(I + U, I + G * H^2))`.
+   * Allocations are O(N) in the worst case, but disjoint subtrees from this tree are reused.
    * @param other The tree whose keys will be removed from the result.
    * @returns A new `BTreeEx` representing `this \ other`.
    * @throws Error if the trees were created with different comparators or max node sizes.

--- a/extended/intersect.d.ts
+++ b/extended/intersect.d.ts
@@ -3,10 +3,10 @@ import BTree from '../b+tree';
  * Returns a new tree containing only keys present in both input trees.
  * Neither tree is modified.
  *
- * Complexity is O(N + M) in the fully overlapping case and additionally bounded by O(log(N + M) * D),
- * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
  * @param treeA First tree to intersect.
  * @param treeB Second tree to intersect.
  * @param combineFn Called for keys that appear in both trees. Return the desired value.

--- a/extended/intersect.js
+++ b/extended/intersect.js
@@ -10,10 +10,10 @@ var bulkLoad_1 = require("./bulkLoad");
  * Returns a new tree containing only keys present in both input trees.
  * Neither tree is modified.
  *
- * Complexity is O(N + M) in the fully overlapping case and additionally bounded by O(log(N + M) * D),
- * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
  * @param treeA First tree to intersect.
  * @param treeB Second tree to intersect.
  * @param combineFn Called for keys that appear in both trees. Return the desired value.

--- a/extended/intersect.ts
+++ b/extended/intersect.ts
@@ -7,10 +7,10 @@ import { bulkLoadRoot } from './bulkLoad';
  * Returns a new tree containing only keys present in both input trees.
  * Neither tree is modified.
  *
- * Complexity is O(N + M) in the fully overlapping case and additionally bounded by O(log(N + M) * D),
- * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H))`.
  * @param treeA First tree to intersect.
  * @param treeB Second tree to intersect.
  * @param combineFn Called for keys that appear in both trees. Return the desired value.

--- a/extended/subtract.d.ts
+++ b/extended/subtract.d.ts
@@ -3,11 +3,11 @@ import BTree from '../b+tree';
  * Returns a new tree containing only the keys that are present in `targetTree` but not `subtractTree` (set subtraction).
  * Neither tree is modified.
  *
- * Complexity is O(N + M) for time and O(N) for allocations in the worst case. Additionally, time is bounded by
- * O(log(N + M) * D1) and space by O(log N * D2), where `D1` is the number of disjoint key ranges between the trees
- * and `D2` is the number of disjoint ranges inside `targetTree`, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the time complexity is `O(min(I + U, I + G * H^2))`.
+ * Allocations are O(N) in the worst case, but disjoint subtrees from `targetTree` are reused.
  * @param targetTree The tree to subtract from.
  * @param subtractTree The tree whose keys will be removed from the result.
  * @returns A new tree that contains the subtraction result.

--- a/extended/subtract.js
+++ b/extended/subtract.js
@@ -6,11 +6,11 @@ var decompose_1 = require("./decompose");
  * Returns a new tree containing only the keys that are present in `targetTree` but not `subtractTree` (set subtraction).
  * Neither tree is modified.
  *
- * Complexity is O(N + M) for time and O(N) for allocations in the worst case. Additionally, time is bounded by
- * O(log(N + M) * D1) and space by O(log N * D2), where `D1` is the number of disjoint key ranges between the trees
- * and `D2` is the number of disjoint ranges inside `targetTree`, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the time complexity is `O(min(I + U, I + G * H^2))`.
+ * Allocations are O(N) in the worst case, but disjoint subtrees from `targetTree` are reused.
  * @param targetTree The tree to subtract from.
  * @param subtractTree The tree whose keys will be removed from the result.
  * @returns A new tree that contains the subtraction result.

--- a/extended/subtract.ts
+++ b/extended/subtract.ts
@@ -6,11 +6,11 @@ import { buildFromDecomposition, decompose } from './decompose';
  * Returns a new tree containing only the keys that are present in `targetTree` but not `subtractTree` (set subtraction).
  * Neither tree is modified.
  *
- * Complexity is O(N + M) for time and O(N) for allocations in the worst case. Additionally, time is bounded by
- * O(log(N + M) * D1) and space by O(log N * D2), where `D1` is the number of disjoint key ranges between the trees
- * and `D2` is the number of disjoint ranges inside `targetTree`, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the time complexity is `O(min(I + U, I + G * H^2))`.
+ * Allocations are O(N) in the worst case, but disjoint subtrees from `targetTree` are reused.
  * @param targetTree The tree to subtract from.
  * @param subtractTree The tree whose keys will be removed from the result.
  * @returns A new tree that contains the subtraction result.

--- a/extended/union.d.ts
+++ b/extended/union.d.ts
@@ -2,10 +2,11 @@ import BTree from '../b+tree';
 /**
  * Efficiently unions two trees, reusing subtrees wherever possible without mutating either input.
  *
- * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height (counting a leaf root as height 1),
+ * and `G` the number of maximal runs of one-tree-only keys in merged key order. With a fixed max node size and
+ * normally occupied nodes, the complexity excluding time spent in `combineFn` is
+ * `O(H + I + min(U, G * H^2))`, and therefore `O(N + M)` in the worst case.
  * @param treeA First tree to union.
  * @param treeB Second tree to union.
  * @param combineFn Called for keys that appear in both trees. Return the desired value, or

--- a/extended/union.d.ts
+++ b/extended/union.d.ts
@@ -3,10 +3,9 @@ import BTree from '../b+tree';
  * Efficiently unions two trees, reusing subtrees wherever possible without mutating either input.
  *
  * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
- * the number of keys present in exactly one tree, `H` the larger tree height (counting a leaf root as height 1),
- * and `G` the number of maximal runs of one-tree-only keys in merged key order. With a fixed max node size and
- * normally occupied nodes, the complexity excluding time spent in `combineFn` is
- * `O(H + I + min(U, G * H^2))`, and therefore `O(N + M)` in the worst case.
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H^2))`.
  * @param treeA First tree to union.
  * @param treeB Second tree to union.
  * @param combineFn Called for keys that appear in both trees. Return the desired value, or

--- a/extended/union.js
+++ b/extended/union.js
@@ -6,10 +6,9 @@ var decompose_1 = require("./decompose");
  * Efficiently unions two trees, reusing subtrees wherever possible without mutating either input.
  *
  * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
- * the number of keys present in exactly one tree, `H` the larger tree height (counting a leaf root as height 1),
- * and `G` the number of maximal runs of one-tree-only keys in merged key order. With a fixed max node size and
- * normally occupied nodes, the complexity excluding time spent in `combineFn` is
- * `O(H + I + min(U, G * H^2))`, and therefore `O(N + M)` in the worst case.
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H^2))`.
  * @param treeA First tree to union.
  * @param treeB Second tree to union.
  * @param combineFn Called for keys that appear in both trees. Return the desired value, or

--- a/extended/union.js
+++ b/extended/union.js
@@ -5,10 +5,11 @@ var decompose_1 = require("./decompose");
 /**
  * Efficiently unions two trees, reusing subtrees wherever possible without mutating either input.
  *
- * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height (counting a leaf root as height 1),
+ * and `G` the number of maximal runs of one-tree-only keys in merged key order. With a fixed max node size and
+ * normally occupied nodes, the complexity excluding time spent in `combineFn` is
+ * `O(H + I + min(U, G * H^2))`, and therefore `O(N + M)` in the worst case.
  * @param treeA First tree to union.
  * @param treeB Second tree to union.
  * @param combineFn Called for keys that appear in both trees. Return the desired value, or

--- a/extended/union.ts
+++ b/extended/union.ts
@@ -5,10 +5,11 @@ import { decompose, buildFromDecomposition } from "./decompose";
 /**
  * Efficiently unions two trees, reusing subtrees wherever possible without mutating either input.
  *
- * Complexity is O(N + M) when the trees overlap heavily, and additionally bounded by O(log(N + M) * D)
- * where `D` is the number of disjoint key ranges, because disjoint subtrees are skipped entirely.
- * In practice, that means for keys of random distribution the performance is linear and for keys with significant
- * numbers of non-overlapping key ranges it is much faster.
+ * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
+ * the number of keys present in exactly one tree, `H` the larger tree height (counting a leaf root as height 1),
+ * and `G` the number of maximal runs of one-tree-only keys in merged key order. With a fixed max node size and
+ * normally occupied nodes, the complexity excluding time spent in `combineFn` is
+ * `O(H + I + min(U, G * H^2))`, and therefore `O(N + M)` in the worst case.
  * @param treeA First tree to union.
  * @param treeB Second tree to union.
  * @param combineFn Called for keys that appear in both trees. Return the desired value, or

--- a/extended/union.ts
+++ b/extended/union.ts
@@ -6,10 +6,9 @@ import { decompose, buildFromDecomposition } from "./decompose";
  * Efficiently unions two trees, reusing subtrees wherever possible without mutating either input.
  *
  * Let `N` and `M` be the input sizes, `I` the number of keys present in both trees, `U = N + M - 2I`
- * the number of keys present in exactly one tree, `H` the larger tree height (counting a leaf root as height 1),
- * and `G` the number of maximal runs of one-tree-only keys in merged key order. With a fixed max node size and
- * normally occupied nodes, the complexity excluding time spent in `combineFn` is
- * `O(H + I + min(U, G * H^2))`, and therefore `O(N + M)` in the worst case.
+ * the number of keys present in exactly one tree, `H` the larger tree height, and `G` the number of maximal
+ * runs of keys belonging exclusively to one particular tree in merged key order. With a fixed max node size
+ * and normally occupied nodes, the complexity is `O(min(I + U, I + G * H^2))`.
  * @param treeA First tree to union.
  * @param treeB Second tree to union.
  * @param combineFn Called for keys that appear in both trees. Return the desired value, or

--- a/test/union.test.ts
+++ b/test/union.test.ts
@@ -609,6 +609,16 @@ describe.each([32, 10, 4])('BTree union tests with fanout %i', (maxNodeSize) => 
     expect(result.toArray()).toEqual([[1, 10], [4, 400]]);
   });
 
+  it('Union excluding every key returns an empty tree', () => {
+    const keys = range(0, maxNodeSize * 2 + 1);
+    const tree1 = buildTree(keys);
+    const tree2 = buildTree(keys, 10);
+
+    const { result } = expectUnionMatchesBaseline(tree1, tree2, () => undefined);
+    expect(result.size).toBe(0);
+    expectRootLeafState(result, true);
+  });
+
   it('Union with large disjoint ranges', () => {
     const tree1 = new BTreeEx<number, number>([], compareNumbers, maxNodeSize);
     const tree2 = new BTreeEx<number, number>([], compareNumbers, maxNodeSize);


### PR DESCRIPTION
This PR fixes an issue in which certain extended algorithms misbehave when two non-empty key-identical trees are processed with compareFn => undefined, resulting in a malformed tree. It also updates the runtime documentation of the extended algorithms with the correct bound.